### PR TITLE
Update pyproject.toml to support Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.8"
 requests = "^2.25.1"
 requests-toolbelt = "^0.9.1"
 ujson = "^4.0.2"


### PR DESCRIPTION
The library also works without a problem with Python 3.8, so I think we should include it in the supported Python versions