### PR TITLE
set urllib3 log level to warning

### DIFF
--- a/axiom/datasets.py
+++ b/axiom/datasets.py
@@ -189,7 +189,6 @@ class DatasetsClient:  # pylint: disable=R0903
 
         # override the default header and set the value from the passed parameter
         res = self.session.post(path, data=payload, headers=headers, params=params)
-        self.logger.debug(f"request url: ${res.request.url}")
         status_snake = decamelize(res.json())
         return Util.from_dict(IngestStatus, status_snake)
 

--- a/axiom/logging.py
+++ b/axiom/logging.py
@@ -1,5 +1,5 @@
 """Logging contains the AxiomHandler and related methods to do with logging."""
-from logging import Handler, NOTSET
+from logging import Handler, NOTSET, getLogger, WARNING
 from .client import Client
 
 
@@ -11,6 +11,11 @@ class AxiomHandler(Handler):
 
     def __init__(self, client: Client, dataset: str, level=NOTSET):
         Handler.__init__(self, level)
+        # set urllib3 logging level to warning, check:
+        # https://github.com/axiomhq/axiom-py/issues/23
+        # This is a temp solution that would stop requests
+        # library from flooding the logs with debug messages
+        getLogger("urllib3").setLevel(WARNING)
         self.client = client
         self.dataset = dataset
 


### PR DESCRIPTION
enforce log level for urllib3 to `WARNING`, so that it doesn't flood the logs
with debuging messages.