### PR TITLE
promote apl query over query_legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ access_token = os.getenv("AXIOM_TOKEN")
 org_id = os.getenv("AXIOM_ORG_ID")
 
 
-client.datasets.apl_query(r"['my-dataset'] | where foo == 'bar' | limit 100")
+client.datasets.query(r"['my-dataset'] | where foo == 'bar' | limit 100")
 ```
 
 ## Contributing

--- a/axiom/datasets.py
+++ b/axiom/datasets.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass, asdict, field
 from datetime import datetime, timedelta, timezone
 
 from .util import Util
-from .query import Query, QueryOptions, QueryKind, AplQueryResult
-from .query.result import QueryResult
+from .query import QueryLegacy, QueryOptions, QueryKind, QueryResult
+from .query.result import QueryLegacyResult
 
 
 @dataclass
@@ -244,7 +244,9 @@ class DatasetsClient:  # pylint: disable=R0903
         path = "datasets/%s" % id
         self.session.delete(path)
 
-    def query(self, id: str, query: Query, opts: QueryOptions) -> QueryResult:
+    def query_legacy(
+        self, id: str, query: QueryLegacy, opts: QueryOptions
+    ) -> QueryLegacyResult:
         """Executes the given query on the dataset identified by its id."""
         if not opts.saveAsKind or (opts.saveAsKind == QueryKind.APL):
             raise WrongQueryKindException(
@@ -257,14 +259,14 @@ class DatasetsClient:  # pylint: disable=R0903
         self.logger.debug("sending query %s" % payload)
         params = self._prepare_query_options(opts)
         res = self.session.post(path, data=payload, params=params)
-        result = Util.from_dict(QueryResult, res.json())
+        result = Util.from_dict(QueryLegacyResult, res.json())
         self.logger.debug(f"query result: {result}")
         query_id = res.headers.get("X-Axiom-History-Query-Id")
         self.logger.info(f"received query result with query_id: {query_id}")
         result.savedQueryID = query_id
         return result
 
-    def apl_query(self, apl: str, opts: AplOptions) -> AplQueryResult:
+    def query(self, apl: str, opts: AplOptions) -> QueryResult:
         """Executes the given apl query on the dataset identified by its id."""
 
         path = "datasets/_apl"
@@ -275,7 +277,7 @@ class DatasetsClient:  # pylint: disable=R0903
         self.logger.debug("sending query %s" % payload)
         params = self._prepare_apl_options(opts)
         res = self.session.post(path, data=payload, params=params)
-        result = Util.from_dict(AplQueryResult, res.json())
+        result = Util.from_dict(QueryResult, res.json())
         self.logger.debug(f"apl query result: {result}")
         query_id = res.headers.get("X-Axiom-History-Query-Id")
         self.logger.info(f"received query result with query_id: {query_id}")

--- a/axiom/datasets.py
+++ b/axiom/datasets.py
@@ -266,6 +266,10 @@ class DatasetsClient:  # pylint: disable=R0903
         result.savedQueryID = query_id
         return result
 
+    def apl_query(self, apl: str, opts: AplOptions) -> QueryResult:
+        """Executes the given apl query on the dataset identified by its id."""
+        return self.query(apl, opts)
+
     def query(self, apl: str, opts: AplOptions) -> QueryResult:
         """Executes the given apl query on the dataset identified by its id."""
 

--- a/axiom/query/query.py
+++ b/axiom/query/query.py
@@ -50,7 +50,7 @@ class Projection:
 
 
 @dataclass
-class Query:
+class QueryLegacy:
     """represents a query that gets executed on a dataset."""
 
     # start time of the query. Required.

--- a/axiom/query/result.py
+++ b/axiom/query/result.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional
 from enum import Enum
 
-from .query import Query
+from .query import QueryLegacy
 
 
 class MessageCode(Enum):
@@ -136,7 +136,7 @@ class Timeseries:
 
 
 @dataclass
-class QueryResult:
+class QueryLegacyResult:
     """Result is the result of a query."""
 
     # Status of the query result.
@@ -152,10 +152,10 @@ class QueryResult:
 
 
 @dataclass
-class AplQueryResult:
+class QueryResult:
     """Result is the result of apl query."""
 
-    request: Query
+    request: QueryLegacy
     # Status of the apl query result.
     status: QueryStatus
     # Matches are the events that matched the apl query.

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -18,8 +18,8 @@ from axiom import (
     WrongQueryKindException,
 )
 from axiom.query import (
-    AplQueryResult,
-    Query,
+    QueryResult,
+    QueryLegacy,
     QueryOptions,
     QueryKind,
     Filter,
@@ -29,7 +29,7 @@ from axiom.query import (
     FilterOperation,
 )
 from axiom.query.result import (
-    QueryResult,
+    QueryLegacyResult,
     QueryStatus,
     Entry,
     EntryGroup,
@@ -196,13 +196,13 @@ class TestDatasets(unittest.TestCase):
         startTime = datetime.utcnow() - timedelta(minutes=2)
         endTime = datetime.utcnow()
 
-        q = Query(startTime=startTime, endTime=endTime)
+        q = QueryLegacy(startTime=startTime, endTime=endTime)
         opts = QueryOptions(
             streamingDuration=timedelta(seconds=60),
             nocache=True,
             saveAsKind=QueryKind.ANALYTICS,
         )
-        qr = self.client.datasets.query(self.dataset_name, q, opts)
+        qr = self.client.datasets.query_legacy(self.dataset_name, q, opts)
 
         self.assertIsNotNone(qr.savedQueryID)
         self.assertEqual(len(qr.matches), len(self.events))
@@ -221,7 +221,7 @@ class TestDatasets(unittest.TestCase):
             save=False,
             format=AplResultFormat.Legacy,
         )
-        qr = self.client.datasets.apl_query(apl, opts)
+        qr = self.client.datasets.query(apl, opts)
 
         self.assertEqual(len(qr.matches), len(self.events))
 
@@ -234,10 +234,10 @@ class TestDatasets(unittest.TestCase):
             nocache=True,
             saveAsKind=QueryKind.APL,
         )
-        q = Query(startTime, endTime)
+        q = QueryLegacy(startTime, endTime)
 
         try:
-            self.client.datasets.query(self.dataset_name, q, opts)
+            self.client.datasets.query_legacy(self.dataset_name, q, opts)
         except WrongQueryKindException as err:
             self.logger.info("passing kind apl to query raised exception as expected")
             return
@@ -251,7 +251,7 @@ class TestDatasets(unittest.TestCase):
         aggregations = [
             Aggregation(alias="event_count", op=AggregationOperation.COUNT, field="*")
         ]
-        q = Query(startTime, endTime, aggregations=aggregations)
+        q = QueryLegacy(startTime, endTime, aggregations=aggregations)
         q.groupBy = ["success", "remote_ip"]
         q.filter = Filter(FilterOperation.EQUAL, "response", 304)
         q.order = [
@@ -261,7 +261,7 @@ class TestDatasets(unittest.TestCase):
         q.virtualFields = [VirtualField("success", "response < 400")]
         q.project = [Projection("remote_ip", "ip")]
 
-        res = self.client.datasets.query(self.dataset_name, q, QueryOptions())
+        res = self.client.datasets.query_legacy(self.dataset_name, q, QueryOptions())
 
         # self.assertEqual(len(self.events), res.status.rowsExamined)
         self.assertEqual(len(self.events), res.status.rowsMatched)


### PR DESCRIPTION
# ⚠️ Breaking Changes:
- The query function now does an APL query, if you want to keep using the non-apl query function, you can use queryLegacy. 
queryLegacy will go away in the future.