### PR TITLE
Add missing imports in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ client = axiom.Client("<api token>", "<org id>")
 Create and use a client like this:
 
 ```py
-import os
 import axiom
+import rfc3339
+from datetime import datetime,timedelta
 
 client = axiom.Client()
 


### PR DESCRIPTION
The datatime,timedelta and rfc3339 imports were missing from the readme example
And the os module is not needed