### PR TITLE
feat(axiom-py): Add support for creating and deleting API tokens

### DIFF
--- a/axiom/__init__.py
+++ b/axiom/__init__.py
@@ -7,3 +7,4 @@ __version__ = "0.1.0-beta.2"
 from .client import *
 from .datasets import *
 from .annotations import *
+from .tokens import *

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -271,16 +271,23 @@ class Client:  # pylint: disable=R0903
         return result
 
     def create_api_token(self, opts: TokenAttributes) -> str:
-        res = self.session.post('/v2/tokens', data=asdict(opts))
+        """Creates a new API token with permissions specified in a TokenAttributes object."""
+        res = self.session.post(
+            '/v2/tokens',
+            data=ujson.dumps(
+                asdict(opts),
+                default=Util.handle_json_serialization
+            )
+        )
 
         # Return ID/token for debugging purposes.
-        # TODO: error checking and reporting, return a dataclass with id/token attrs
+        # TODO: return a dataclass with id/token attrs
         response = res.json()
         return f'{response["id"]}:{response["token"]}'
 
     def delete_api_token(self, token_id: str) -> None:
+        """Delete an API token using its ID string."""
         self.session.delete(f'/v2/tokens/{token_id}')
-        # TODO: Error checking and reporting.
 
     def _prepare_query_options(self, opts: QueryOptions) -> Dict[str, Any]:
         """returns the query options as a Dict, handles any renaming for key fields."""

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -6,7 +6,7 @@ import gzip
 import ujson
 import os
 
-from .tokens import TokenAttributes
+from .tokens import TokenAttributes, Token
 from .util import Util
 from enum import Enum
 from humps import decamelize
@@ -270,7 +270,7 @@ class Client:  # pylint: disable=R0903
 
         return result
 
-    def create_api_token(self, opts: TokenAttributes) -> str:
+    def create_api_token(self, opts: TokenAttributes) -> Token:
         """Creates a new API token with permissions specified in a TokenAttributes object."""
         res = self.session.post(
             '/v2/tokens',
@@ -280,10 +280,9 @@ class Client:  # pylint: disable=R0903
             )
         )
 
-        # Return ID/token for debugging purposes.
-        # TODO: return a dataclass with id/token attrs
+        # Return the new token and ID.
         response = res.json()
-        return f'{response["id"]}:{response["token"]}'
+        return Token(id=response["id"], token=response["token"])
 
     def delete_api_token(self, token_id: str) -> None:
         """Delete an API token using its ID string."""

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -5,12 +5,14 @@ import dacite
 import gzip
 import ujson
 import os
+
+from .tokens import TokenAttributes
 from .util import Util
 from enum import Enum
 from humps import decamelize
 from typing import Optional, List, Dict, Any
 from logging import getLogger
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from requests_toolbelt.sessions import BaseUrlSession
 from requests_toolbelt.utils.dump import dump_response
@@ -265,7 +267,20 @@ class Client:  # pylint: disable=R0903
         query_id = res.headers.get("X-Axiom-History-Query-Id")
         self.logger.info(f"received query result with query_id: {query_id}")
         result.savedQueryID = query_id
+
         return result
+
+    def create_api_token(self, opts: TokenAttributes) -> str:
+        res = self.session.post('/v2/tokens', data=asdict(opts))
+
+        # Return ID/token for debugging purposes.
+        # TODO: error checking and reporting, return a dataclass with id/token attrs
+        response = res.json()
+        return f'{response["id"]}:{response["token"]}'
+
+    def delete_api_token(self, token_id: str) -> None:
+        self.session.delete(f'/v2/tokens/{token_id}')
+        # TODO: Error checking and reporting.
 
     def _prepare_query_options(self, opts: QueryOptions) -> Dict[str, Any]:
         """returns the query options as a Dict, handles any renaming for key fields."""

--- a/axiom/tokens.py
+++ b/axiom/tokens.py
@@ -12,13 +12,13 @@ class TokenDatasetCapabilities:
     """
 
     # Ability to ingest data. Optional.
-    ingest: Literal["create"]
+    ingest: Literal["create"] | None = None
     # Ability to query data. Optional.
-    query: Literal["read"]
+    query: Literal["read"] | None = None
     # Ability to use starred queries. Optional.
-    starredQueries: Literal["create", "read", "update", "delete"]
+    starredQueries: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use virtual fields. Optional.
-    virtualFields: Literal["create", "read", "update", "delete"]
+    virtualFields: Literal["create", "read", "update", "delete"] | None = None
 
 
 @dataclass
@@ -29,31 +29,31 @@ class TokenOrganizationCapabilities:
     """
 
     # Ability to use annotations. Optional.
-    annotations: Literal["create", "read", "update", "delete"]
+    annotations: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use api tokens. Optional.
-    apiTokens: Literal["create", "read", "update", "delete"]
+    apiTokens: Literal["create", "read", "update", "delete"] | None = None
     # Ability to access billing. Optional.
-    billing: Literal["read", "update"]
+    billing: Literal["read", "update"] | None = None
     # Ability to use dashboards. Optional.
-    dashboards: Literal["create", "read", "update", "delete"]
+    dashboards: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use datasets. Optional.
-    datasets: Literal["create", "read", "update", "delete"]
+    datasets: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use endpoints. Optional.
-    endpoints: Literal["create", "read", "update", "delete"]
+    endpoints: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use flows. Optional.
-    flows: Literal["create", "read", "update", "delete"]
+    flows: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use integrations. Optional.
-    integrations: Literal["create", "read", "update", "delete"]
+    integrations: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use monitors. Optional.
-    monitors: Literal["create", "read", "update", "delete"]
+    monitors: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use notifiers. Optional.
-    notifiers: Literal["create", "read", "update", "delete"]
+    notifiers: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use role-based access controls. Optional.
-    rbac: Literal["create", "read", "update", "delete"]
+    rbac: Literal["create", "read", "update", "delete"] | None = None
     # Ability to use shared access keys. Optional.
-    sharedAccessKeys: Literal["read", "update"]
+    sharedAccessKeys: Literal["read", "update"] | None = None
     # Ability to use users. Optional.
-    users: Literal["create", "read", "update", "delete"]
+    users: Literal["create", "read", "update", "delete"] | None = None
 
 
 @dataclass
@@ -63,13 +63,13 @@ class TokenAttributes:
     POST /tokens API accepts.
     """
 
-    # The token's dataset-level capabilities. Keyed on dataset name. Optional.
-    datasetCapabilities: dict[str, TokenDatasetCapabilities]
-    # Description for the API token. Optional.
-    description: str
-    # Expiration date for the API token. Optional.
-    expiresAt: str | None
     # Name for the token. Required.
     name: str
+    # The token's dataset-level capabilities. Keyed on dataset name. Optional.
+    datasetCapabilities: dict[str, TokenDatasetCapabilities] | None = None
+    # Description for the API token. Optional.
+    description: str | None = None
+    # Expiration date for the API token. Optional.
+    expiresAt: str | None = None
     # The token's organization-level capabilities. Optional.
-    orgCapabilities: TokenOrganizationCapabilities
+    orgCapabilities: TokenOrganizationCapabilities | None = None

--- a/axiom/tokens.py
+++ b/axiom/tokens.py
@@ -12,13 +12,13 @@ class TokenDatasetCapabilities:
     """
 
     # Ability to ingest data. Optional.
-    ingest: Literal["create"] | None = None
+    ingest: list[Literal["create"]] | None = None
     # Ability to query data. Optional.
-    query: Literal["read"] | None = None
+    query: list[Literal["read"]] | None = None
     # Ability to use starred queries. Optional.
-    starredQueries: Literal["create", "read", "update", "delete"] | None = None
+    starredQueries: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use virtual fields. Optional.
-    virtualFields: Literal["create", "read", "update", "delete"] | None = None
+    virtualFields: list[Literal["create", "read", "update", "delete"]] | None = None
 
 
 @dataclass
@@ -29,31 +29,31 @@ class TokenOrganizationCapabilities:
     """
 
     # Ability to use annotations. Optional.
-    annotations: Literal["create", "read", "update", "delete"] | None = None
+    annotations: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use api tokens. Optional.
-    apiTokens: Literal["create", "read", "update", "delete"] | None = None
+    apiTokens: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to access billing. Optional.
-    billing: Literal["read", "update"] | None = None
+    billing: list[Literal["read", "update"]] | None = None
     # Ability to use dashboards. Optional.
-    dashboards: Literal["create", "read", "update", "delete"] | None = None
+    dashboards: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use datasets. Optional.
-    datasets: Literal["create", "read", "update", "delete"] | None = None
+    datasets: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use endpoints. Optional.
-    endpoints: Literal["create", "read", "update", "delete"] | None = None
+    endpoints: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use flows. Optional.
-    flows: Literal["create", "read", "update", "delete"] | None = None
+    flows: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use integrations. Optional.
-    integrations: Literal["create", "read", "update", "delete"] | None = None
+    integrations: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use monitors. Optional.
-    monitors: Literal["create", "read", "update", "delete"] | None = None
+    monitors: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use notifiers. Optional.
-    notifiers: Literal["create", "read", "update", "delete"] | None = None
+    notifiers: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use role-based access controls. Optional.
-    rbac: Literal["create", "read", "update", "delete"] | None = None
+    rbac: list[Literal["create", "read", "update", "delete"]] | None = None
     # Ability to use shared access keys. Optional.
-    sharedAccessKeys: Literal["read", "update"] | None = None
+    sharedAccessKeys: list[Literal["read", "update"]] | None = None
     # Ability to use users. Optional.
-    users: Literal["create", "read", "update", "delete"] | None = None
+    users: list[Literal["create", "read", "update", "delete"]] | None = None
 
 
 @dataclass

--- a/axiom/tokens.py
+++ b/axiom/tokens.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class TokenDatasetCapabilities:
+    """
+    TokenDatasetCapabilities describes the dataset-level permissions
+    which a token can be assigned.
+    Each token can have multiple dataset-level capability objects;
+    one per dataset.
+    """
+
+    # Ability to ingest data. Optional.
+    ingest: Literal["create"]
+    # Ability to query data. Optional.
+    query: Literal["read"]
+    # Ability to use starred queries. Optional.
+    starredQueries: Literal["create", "read", "update", "delete"]
+    # Ability to use virtual fields. Optional.
+    virtualFields: Literal["create", "read", "update", "delete"]
+
+
+@dataclass
+class TokenOrganizationCapabilities:
+    """
+    TokenOrganizationCapabilities describes the org-level permissions
+    which a token can be assigned.
+    """
+
+    # Ability to use annotations. Optional.
+    annotations: Literal["create", "read", "update", "delete"]
+    # Ability to use api tokens. Optional.
+    apiTokens: Literal["create", "read", "update", "delete"]
+    # Ability to access billing. Optional.
+    billing: Literal["read", "update"]
+    # Ability to use dashboards. Optional.
+    dashboards: Literal["create", "read", "update", "delete"]
+    # Ability to use datasets. Optional.
+    datasets: Literal["create", "read", "update", "delete"]
+    # Ability to use endpoints. Optional.
+    endpoints: Literal["create", "read", "update", "delete"]
+    # Ability to use flows. Optional.
+    flows: Literal["create", "read", "update", "delete"]
+    # Ability to use integrations. Optional.
+    integrations: Literal["create", "read", "update", "delete"]
+    # Ability to use monitors. Optional.
+    monitors: Literal["create", "read", "update", "delete"]
+    # Ability to use notifiers. Optional.
+    notifiers: Literal["create", "read", "update", "delete"]
+    # Ability to use role-based access controls. Optional.
+    rbac: Literal["create", "read", "update", "delete"]
+    # Ability to use shared access keys. Optional.
+    sharedAccessKeys: Literal["read", "update"]
+    # Ability to use users. Optional.
+    users: Literal["create", "read", "update", "delete"]
+
+
+@dataclass
+class TokenAttributes:
+    """
+    TokenAttributes describes the set of input parameters that the
+    POST /tokens API accepts.
+    """
+
+    # The token's dataset-level capabilities. Keyed on dataset name. Optional.
+    datasetCapabilities: dict[str, TokenDatasetCapabilities]
+    # Description for the API token. Optional.
+    description: str
+    # Expiration date for the API token. Optional.
+    expiresAt: str | None
+    # Name for the token. Required.
+    name: str
+    # The token's organization-level capabilities. Optional.
+    orgCapabilities: TokenOrganizationCapabilities

--- a/axiom/tokens.py
+++ b/axiom/tokens.py
@@ -73,3 +73,13 @@ class TokenAttributes:
     expiresAt: str | None = None
     # The token's organization-level capabilities. Optional.
     orgCapabilities: TokenOrganizationCapabilities | None = None
+
+
+@dataclass
+class Token:
+    """
+    Token contains the response from a call to POST /tokens.
+    It includes the API token itself, and an ID which can be used to reference it later.
+    """
+    id: str
+    token: str


### PR DESCRIPTION
 ### Summary

This PR adds support for creating and deleting API tokens using the `axiom-py` package.

The dataclasses for request and response structures are in a new `axiom/tokens.py` file, and the API calls themselves are in the client logic.

 ### Test Plan

Using a test script, call the `create_api_token` function to create a new token with arbitrary attributes. Check that the token was created in Axiom, then delete it with the `delete_api_token` function.

I added a pytest, too.