### PR TITLE
feat(typing): Prefer `object` over `Any`

### DIFF
--- a/axiom/client.py
+++ b/axiom/client.py
@@ -8,7 +8,7 @@ import os
 from .util import Util
 from enum import Enum
 from humps import decamelize
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict
 from logging import getLogger
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
@@ -267,7 +267,7 @@ class Client:  # pylint: disable=R0903
         result.savedQueryID = query_id
         return result
 
-    def _prepare_query_options(self, opts: QueryOptions) -> Dict[str, Any]:
+    def _prepare_query_options(self, opts: QueryOptions) -> Dict[str, object]:
         """returns the query options as a Dict, handles any renaming for key fields."""
         if opts is None:
             return {}
@@ -283,7 +283,7 @@ class Client:  # pylint: disable=R0903
 
         return params
 
-    def _prepare_ingest_options(self, opts: Optional[IngestOptions]) -> Dict[str, Any]:
+    def _prepare_ingest_options(self, opts: Optional[IngestOptions]) -> Dict[str, object]:
         """the query params for ingest api are expected in a format
         that couldn't be defined as a variable name because it has a dash.
         As a work around, we create the params dict manually."""
@@ -301,7 +301,7 @@ class Client:  # pylint: disable=R0903
 
         return params
 
-    def _prepare_apl_options(self, opts: Optional[AplOptions]) -> Dict[str, Any]:
+    def _prepare_apl_options(self, opts: Optional[AplOptions]) -> Dict[str, object]:
         """Prepare the apl query options for the request."""
         params = {}
 
@@ -320,7 +320,7 @@ class Client:  # pylint: disable=R0903
 
     def _prepare_apl_payload(
         self, apl: str, opts: Optional[AplOptions]
-    ) -> Dict[str, Any]:
+    ) -> Dict[str, object]:
         """Prepare the apl query options for the request."""
         params = {}
         params["apl"] = apl

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -283,7 +283,9 @@ class Client:  # pylint: disable=R0903
 
         return params
 
-    def _prepare_ingest_options(self, opts: Optional[IngestOptions]) -> Dict[str, object]:
+    def _prepare_ingest_options(
+        self, opts: Optional[IngestOptions]
+    ) -> Dict[str, object]:
         """the query params for ingest api are expected in a format
         that couldn't be defined as a variable name because it has a dash.
         As a work around, we create the params dict manually."""

--- a/axiom/query/result.py
+++ b/axiom/query/result.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from enum import Enum
 
 from .query import QueryLegacy
@@ -87,7 +87,7 @@ class Entry:
     _rowId: str
     # contains the raw data of the event (with filters and aggregations
     # applied).
-    data: Dict[str, Any]
+    data: Dict[str, object]
 
 
 @dataclass
@@ -96,7 +96,7 @@ class EntryGroupAgg:
 
     # alias is the aggregations alias. If it wasn't specified at query time, it
     # is the uppercased string representation of the aggregation operation.
-    value: Any
+    value: object
     op: str = field(default="")
     # value is the result value of the aggregation.
 
@@ -108,7 +108,7 @@ class EntryGroup:
     # the unique id of the group.
     id: int
     # group maps the fieldnames to the unique values for the entry.
-    group: Dict[str, Any]
+    group: Dict[str, object]
     # aggregations of the group.
     aggregations: List[EntryGroupAgg]
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -3,7 +3,7 @@
 import os
 
 import unittest
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Optional
 from logging import getLogger
 from requests.exceptions import HTTPError
 from datetime import timedelta

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -3,7 +3,7 @@
 import os
 
 import unittest
-from typing import List, Dict, Any
+from typing import List, Dict
 from logging import getLogger
 from requests.exceptions import HTTPError
 from datetime import timedelta
@@ -17,7 +17,7 @@ from axiom import (
 
 class TestDatasets(unittest.TestCase):
     dataset_name: str
-    events: List[Dict[str, Any]]
+    events: List[Dict[str, object]]
     client: Client
     events_time_format = "%d/%b/%Y:%H:%M:%S +0000"
 


### PR DESCRIPTION
This PR replaces all uses of `Any` with `object`.

The _correct_ (but obscure) annotation to express "could be anything" is `object`, which will encourage callers to check narrow the type first. Using `Any` disables all type checkers instead.

I stumbled over this when I naively wrote `result.data["tag"].lower()`.