### PR TITLE
feat: Add cursor, includeCursor options, bump version

### DIFF
--- a/axiom/client.py
+++ b/axiom/client.py
@@ -98,11 +98,18 @@ class WrongQueryKindException(Exception):
 class AplOptions:
     """AplOptions specifies the optional parameters for the apl query method."""
 
+    # Start time for the interval to query.
     start_time: Optional[datetime] = field(default=None)
+    # End time for the interval to query.
     end_time: Optional[datetime] = field(default=None)
-    no_cache: bool = field(default=False)
-    save: bool = field(default=False)
+    # The result format.
     format: AplResultFormat = field(default=AplResultFormat.Legacy)
+    # Cursor is the query cursor. It should be set to the Cursor returned with
+    # a previous query result if it was partial.
+    cursor: str = field(default=None)
+    # IncludeCursor will return the Cursor as part of the query result, if set
+    # to true.
+    includeCursor: bool = field(default=False)
 
 
 def raise_response_error(r):
@@ -303,16 +310,8 @@ class Client:  # pylint: disable=R0903
 
     def _prepare_apl_options(self, opts: Optional[AplOptions]) -> Dict[str, Any]:
         """Prepare the apl query options for the request."""
-        params = {}
+        params = {"format": AplResultFormat.Legacy.value}
 
-        if opts is None:
-            params["format"] = AplResultFormat.Legacy.value
-            return params
-
-        if opts.no_cache:
-            params["nocache"] = opts.no_cache.__str__()
-        if opts.save:
-            params["save"] = opts.save
         if opts.format:
             params["format"] = opts.format.value
 
@@ -330,5 +329,9 @@ class Client:  # pylint: disable=R0903
                 params["startTime"] = opts.start_time
             if opts.end_time:
                 params["endTime"] = opts.end_time
+            if opts.cursor:
+                params["cursor"] = opts.cursor
+            if opts.includeCursor:
+                params["includeCursor"] = opts.includeCursor
 
         return params

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -106,7 +106,7 @@ class AplOptions:
     format: AplResultFormat = field(default=AplResultFormat.Legacy)
     # Cursor is the query cursor. It should be set to the Cursor returned with
     # a previous query result if it was partial.
-    cursor: str = field(default=None)
+    cursor: Optional[str] = field(default=None)
     # IncludeCursor will return the Cursor as part of the query result, if set
     # to true.
     includeCursor: bool = field(default=False)
@@ -326,11 +326,11 @@ class Client:  # pylint: disable=R0903
         params["apl"] = apl
 
         if opts is not None:
-            if opts.start_time:
+            if opts.start_time is not None:
                 params["startTime"] = opts.start_time
-            if opts.end_time:
+            if opts.end_time is not None:
                 params["endTime"] = opts.end_time
-            if opts.cursor:
+            if opts.cursor is not None:
                 params["cursor"] = opts.cursor
             if opts.includeCursor:
                 params["includeCursor"] = opts.includeCursor

--- a/axiom/client.py
+++ b/axiom/client.py
@@ -312,8 +312,9 @@ class Client:  # pylint: disable=R0903
         """Prepare the apl query options for the request."""
         params = {"format": AplResultFormat.Legacy.value}
 
-        if opts.format:
-            params["format"] = opts.format.value
+        if opts is not None:
+            if opts.format:
+                params["format"] = opts.format.value
 
         return params
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "axiom-py"
-version = "0.4.0"
+version = "0.5.0"
 description = "Axiom API Python bindings."
 authors = ["Axiom, Inc."]
 license = "MIT"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -166,8 +166,6 @@ class TestClient(unittest.TestCase):
         opts = AplOptions(
             start_time=startTime,
             end_time=endTime,
-            no_cache=True,
-            save=False,
             format=AplResultFormat.Legacy,
         )
         qr = self.client.query(apl, opts)


### PR DESCRIPTION
This also removes the `no_cache` and `save` flags as they are undocumented.

This also bumps the version to 0.5.0 (breaking change).