### PR TITLE
Even more spring cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,21 +29,8 @@ jobs:
     needs: lint
     strategy:
       fail-fast: true
-      max-parallel: 1
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        environment:
-          - development
-          - staging
-        include:
-          - environment: development
-            url: TESTING_DEV_API_URL
-            token: TESTING_DEV_TOKEN
-            org_id: TESTING_DEV_ORG_ID
-          - environment: staging
-            url: TESTING_STAGING_API_URL
-            token: TESTING_STAGING_TOKEN
-            org_id: TESTING_STAGING_ORG_ID
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -51,11 +38,18 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install uv
         uses: astral-sh/setup-uv@v2
-      - run: uv run pytest
+      - name: Test against development
+        run: uv run pytest
         env:
-          AXIOM_URL: ${{ secrets[matrix.url] }}
-          AXIOM_TOKEN: ${{ secrets[matrix.token] }}
-          AXIOM_ORG_ID: ${{ secrets[matrix.org_id] }}
+          AXIOM_URL: ${{ secrets.TESTING_DEV_API_URL }}
+          AXIOM_TOKEN: ${{ secrets.TESTING_DEV_TOKEN }}
+          AXIOM_ORG_ID: ${{ secrets.TESTING_DEV_ORG_ID }}
+      - name: Test against staging
+        run: uv run pytest
+        env:
+          AXIOM_URL: ${{ secrets.TESTING_STAGING_API_URL }}
+          AXIOM_TOKEN: ${{ secrets.TESTING_STAGING_TOKEN }}
+          AXIOM_ORG_ID: ${{ secrets.TESTING_STAGING_ORG_ID }}
 
   publish:
     name: Publish on PyPi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: local
+  hooks:
+    - id: ruff-check
+      name: ruff check --fix
+      entry: uv run ruff check --fix
+      language: system
+      types: [python]
+    - id: ruff-format
+      name: ruff format
+      entry: uv run ruff format
+      language: system
+      types: [python]

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,0 @@
-[MASTER]
-extension-pkg-whitelist=ujson

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ For a full example, see [`examples/logger.py`](examples/logger.py).
 This project uses [uv](https://docs.astral.sh/uv) for dependency management
 and packaging, so make sure that this is installed.
 
+To lint and format files before commit, run `uvx pre-commit install`.
+
 ## License
 
 Distributed under MIT License (`The MIT License`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,5 @@ dev-dependencies = [
     "responses>=0.25.3",
     "rfc3339>=6.2",
     "iso8601>=1.0.2",
+    "pre-commit>=3.5.0",
 ]

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,0 @@
-with import <nixpkgs> {};
-
-mkShell {
-  nativeBuildInputs = with buildPackages; [ 
-    python38
-    python38Packages.poetry
-  ];
-}

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -36,7 +36,10 @@ class TestAnnotations(unittest.TestCase):
         cls.client.datasets.create(req)
 
     def test_happy_path_crud(self):
-        """Test the happy path of creating, reading, updating, and deleting an annotation."""
+        """
+        Test the happy path of creating, reading, updating, and deleting an
+        annotation.
+        """
         # Create annotation
         req = AnnotationCreateRequest(
             datasets=[self.dataset_name],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -106,7 +106,8 @@ class TestClient(unittest.TestCase):
         opts = IngestOptions(
             "_time",
             "2/Jan/2006:15:04:05 +0000",
-            # CSV_delimiter obviously not valid for JSON, but perfectly fine to test for its presence in this test.
+            # CSV_delimiter obviously not valid for JSON, but perfectly fine to
+            # test for its presence in this test.
             ";",
         )
         res = self.client.ingest(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -83,8 +83,8 @@ class TestDatasets(unittest.TestCase):
                 f"expected test dataset (%{self.dataset_name}) to be deleted",
             )
         except HTTPError as err:
-            # the get method returns 404 error if dataset doesn't exist, so that means
-            # that our tests passed, otherwise, it should fail.
+            # the get method returns 404 error if dataset doesn't exist, so
+            # that means that our tests passed, otherwise, it should fail.
             if err.response.status_code != 404:
                 self.fail(err)
 


### PR DESCRIPTION
* Add pre-commit, configure for (local) ruff
* Add Python 3.12 to test matrix
* Remove (outdated) shell.nix
* Remove .pylintrc, we're using ruff now
* Reduce line lengths in some tests