### PR TITLE
Add client atexit shutdown hook on process exit

### DIFF
--- a/src/axiom_py/client.py
+++ b/src/axiom_py/client.py
@@ -129,7 +129,7 @@ class Client:  # pylint: disable=R0903
     datasets: DatasetsClient
     users: UsersClient
     annotations: AnnotationsClient
-    is_closed: bool  # track if the client has been closed ( for tests )
+    is_closed: bool  # track if the client has been closed (for tests)
 
     def __init__(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,9 @@
 """This module contains the tests for the axiom client."""
 
+import sys
 import os
 import unittest
+from unittest.mock import patch
 import gzip
 import ujson
 import rfc3339
@@ -223,6 +225,17 @@ class TestClient(unittest.TestCase):
         if res.buckets.totals and len(res.buckets.totals):
             agg = res.buckets.totals[0].aggregations[0]
             self.assertEqual("event_count", agg.op)
+
+    @patch("sys.exit")
+    def test_client_shutdown_atexit(self, mock_exit):
+        """Test client shutdown atexit"""
+        # Use the mock to test the firing mechanism
+        self.assertEqual(self.client.is_closed, False)
+        sys.exit()
+        mock_exit.assert_called_once()
+        # Use the hook implementation to assert the client is closed closed
+        self.client.shutdown_hook()
+        self.assertEqual(self.client.is_closed, True)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Fixes #76 by adding support for `atexit` shutdown hooks by default.
The shutdown hook can be called explicitly for more complex ( threaded ) applications