### PR TITLE
Fix missing dependency on iso8601 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Official bindings for the Axiom API"
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
+    "iso8601>=1.0.2",
     "requests>=2.32.3",
     "requests-toolbelt>=1.0.0",
     "ujson>=5.10.0",


### PR DESCRIPTION
Fixes #127 missing iso8601 dependency discovered by @glarec and confirmed with `deptry` tool