### PR TITLE
feat: Add AxiomError for more detailed error messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "axiom-py"
-version = "0.7.0"
+version = "0.8.0"
 description = "Official bindings for the Axiom API"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/axiom_py/__init__.py
+++ b/src/axiom_py/__init__.py
@@ -3,7 +3,7 @@ Axiom Python Client
 """
 
 from .client import (
-    Error,
+    AxiomError,
     IngestFailure,
     IngestStatus,
     IngestOptions,
@@ -27,7 +27,7 @@ from .annotations import (
 )
 
 _all_ = [
-    Error,
+    AxiomError,
     IngestFailure,
     IngestStatus,
     IngestOptions,

--- a/src/axiom_py/version.py
+++ b/src/axiom_py/version.py
@@ -1,3 +1,3 @@
 """The current version"""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,8 +11,8 @@ import responses
 from logging import getLogger
 from datetime import datetime, timedelta
 from .helpers import get_random_name
-from requests.exceptions import HTTPError
 from axiom_py import (
+    AxiomError,
     Client,
     AplOptions,
     AplResultFormat,
@@ -264,7 +264,7 @@ class TestClient(unittest.TestCase):
                     "dataset (%s) was not deleted as part of the test, deleting it now."
                     % cls.dataset_name
                 )
-        except HTTPError as err:
+        except AxiomError as e:
             # nothing to do here, since the dataset doesn't exist
-            cls.logger.warning(err)
+            cls.logger.warning(e)
         cls.logger.info("finish cleaning up after TestClient")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,12 +5,9 @@ import os
 import unittest
 from typing import List, Dict
 from logging import getLogger
-from requests.exceptions import HTTPError
 from datetime import timedelta
 from .helpers import get_random_name
-from axiom_py import (
-    Client,
-)
+from axiom_py import Client, AxiomError
 
 
 class TestDatasets(unittest.TestCase):
@@ -78,11 +75,11 @@ class TestDatasets(unittest.TestCase):
                 dataset,
                 f"expected test dataset (%{self.dataset_name}) to be deleted",
             )
-        except HTTPError as err:
+        except AxiomError as e:
             # the get method returns 404 error if dataset doesn't exist, so
             # that means that our tests passed, otherwise, it should fail.
-            if err.response.status_code != 404:
-                self.fail(err)
+            if e.status != 404:
+                self.fail(e)
 
     @classmethod
     def tearDownClass(cls):
@@ -97,7 +94,7 @@ class TestDatasets(unittest.TestCase):
                     "dataset (%s) was not deleted as part of the test, deleting it now."
                     % cls.dataset_name
                 )
-        except HTTPError as err:
+        except AxiomError as e:
             # nothing to do here, since the dataset doesn't exist
-            cls.logger.warning(err)
+            cls.logger.warning(e)
         cls.logger.info("finish cleaning up after TestDatasets")

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ requires-python = ">=3.8"
 
 [[package]]
 name = "axiom-py"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "dacite" },


### PR DESCRIPTION
This adds the AxiomError exception, parsing the Axiom error response. If the response does not match the JSON format, it falls back to a generic HTTP error.