### PR TITLE
fix: Remove aggregation enum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: chartboost/ruff-action@v1
-      - uses: chartboost/ruff-action@v1
+      - uses: actions/setup-python@v5
         with:
-          args: 'format --check'
+          python-version: ${{ matrix.python }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - run: uv run ruff check
+      - run: uv run ruff format --check
 
   test-integration:
     name: Test Integration

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> Version [v0.9.0](https://github.com/axiomhq/axiom-py/releases/tag/v0.9.0) removes the aggregation operation enum, see [#158](https://github.com/axiomhq/axiom-py/pull/158).
+
 # axiom-py [![CI][ci_badge]][ci] [![PyPI version][pypi_badge]][pypi] [![Python version][version_badge]][pypi]
 
 ```py

--- a/src/axiom_py/query/__init__.py
+++ b/src/axiom_py/query/__init__.py
@@ -1,7 +1,7 @@
 from .query import QueryKind, Order, VirtualField, Projection, QueryLegacy
 from .options import QueryOptions
 from .filter import FilterOperation, BaseFilter, Filter
-from .aggregation import AggregationOperation, Aggregation
+from .aggregation import Aggregation
 from .result import (
     MessagePriority,
     Message,
@@ -25,7 +25,6 @@ __all__ = (
     FilterOperation,
     BaseFilter,
     Filter,
-    AggregationOperation,
     Aggregation,
     MessagePriority,
     Message,

--- a/src/axiom_py/query/aggregation.py
+++ b/src/axiom_py/query/aggregation.py
@@ -1,35 +1,11 @@
-from enum import Enum
 from dataclasses import dataclass, field as dataclass_field
-
-
-class AggregationOperation(Enum):
-    # Works with all types, field should be `*`.
-    COUNT = "count"
-    COUNTIF = "countif"
-    COUNT_DISTINCT = "distinct"
-    COUNTDISTINCTIF = "distinctif"
-    MAKE_SET = "makeset"
-    MAKE_SET_IF = "makesetif"
-
-    # Only works for numbers.
-    SUM = "sum"
-    AVG = "avg"
-    MIN = "min"
-    MAX = "max"
-    TOPK = "topk"
-    PERCENTILES = "percentiles"
-    HISTOGRAM = "histogram"
-    STDEV = "stdev"
-    VARIANCE = "variance"
-    ARGMIN = "argmin"
-    ARGMAX = "argmax"
 
 
 @dataclass
 class Aggregation:
     """Aggregation performed as part of a query."""
 
-    op: AggregationOperation
+    op: str
     field: str = dataclass_field(default="")
     alias: str = dataclass_field(default="")
     argument: any = dataclass_field(default="")

--- a/src/axiom_py/util.py
+++ b/src/axiom_py/util.py
@@ -6,7 +6,6 @@ from typing import Type, TypeVar
 from datetime import datetime, timedelta
 
 from .query import QueryKind
-from .query.aggregation import AggregationOperation
 from .query.result import MessagePriority
 from .query.filter import FilterOperation
 
@@ -50,7 +49,6 @@ def from_dict(data_class: Type[T], data) -> T:
         type_hooks={
             QueryKind: QueryKind,
             datetime: _convert_string_to_datetime,
-            AggregationOperation: AggregationOperation,
             FilterOperation: FilterOperation,
             MessagePriority: MessagePriority,
             timedelta: _convert_string_to_timedelta,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,7 +31,6 @@ from axiom_py.query import (
     Projection,
     FilterOperation,
     Aggregation,
-    AggregationOperation,
 )
 
 
@@ -241,7 +240,7 @@ class TestClient(unittest.TestCase):
         endTime = datetime.utcnow()
         aggregations = [
             Aggregation(
-                alias="event_count", op=AggregationOperation.COUNT, field="*"
+                alias="event_count", op="count", field="*"
             )
         ]
         q = QueryLegacy(startTime, endTime, aggregations=aggregations)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -239,9 +239,7 @@ class TestClient(unittest.TestCase):
         startTime = datetime.utcnow() - timedelta(minutes=2)
         endTime = datetime.utcnow()
         aggregations = [
-            Aggregation(
-                alias="event_count", op="count", field="*"
-            )
+            Aggregation(alias="event_count", op="count", field="*")
         ]
         q = QueryLegacy(startTime, endTime, aggregations=aggregations)
         q.groupBy = ["success", "remote_ip"]


### PR DESCRIPTION
As the request is included in the response, we fail to decode if any aggregations are added after the fact.