### PR TITLE
fix: Use typings.Any instead of any

### DIFF
--- a/src/axiom_py/query/aggregation.py
+++ b/src/axiom_py/query/aggregation.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field as dataclass_field
+from typing import Any
 
 
 @dataclass
@@ -8,4 +9,4 @@ class Aggregation:
     op: str
     field: str = dataclass_field(default="")
     alias: str = dataclass_field(default="")
-    argument: any = dataclass_field(default="")
+    argument: Any = dataclass_field(default="")


### PR DESCRIPTION
This fixes the following error:

    dacite.exceptions.WrongTypeError: wrong value type for field
    "request.aggregations.argument" - should be "any" instead of value "15" of type "int"