### PR TITLE
Do not crash the client if ingestion server is down

### DIFF
--- a/src/axiom_py/client.py
+++ b/src/axiom_py/client.py
@@ -235,12 +235,25 @@ class Client:  # pylint: disable=R0903
         # prepare query params
         params = self._prepare_ingest_options(opts)
 
-        # override the default header and set the value from the passed parameter
-        res = self.session.post(
-            path, data=payload, headers=headers, params=params
-        )
-        status_snake = decamelize(res.json())
-        return from_dict(IngestStatus, status_snake)
+        try:
+            # override the default header and set the value from the passed parameter
+            res = self.session.post(
+                path, data=payload, headers=headers, params=params
+            )
+            status_snake = decamelize(res.json())
+            return from_dict(IngestStatus, status_snake)
+        except AxiomError as err:
+            # Do not crash the app if we cannot save to the logs to Axiom's servers
+            # Log the error to stdout, since we cannot send it to Axiom
+            print(err)
+            return IngestStatus(
+                ingested=0,
+                failed=1,
+                failures=[],
+                processed_bytes=0,
+                blocks_created=0,
+                wal_length=0,
+            )
 
     def ingest_events(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -105,6 +105,22 @@ class TestClient(unittest.TestCase):
         self.client.datasets.get("test")
         assert len(responses.calls) == 3
 
+    @responses.activate
+    def test_backend_failures(self):
+        axiomUrl = os.getenv("AXIOM_URL") or ""
+        url = f"{axiomUrl}/v1/datasets/{self.dataset_name}/ingest"
+        responses.add(responses.POST, url, status=503)
+        responses.add(responses.POST, url, status=503)
+        responses.add(responses.POST, url, status=503)
+        responses.add(responses.POST, url, status=503)
+
+        try:
+            self.client.ingest_events(self.dataset_name, self.events)
+        except:  # noqa: E722
+            # fail the test if we crash during ingestion
+            assert False
+        assert True
+
     def test_step001_ingest(self):
         """Tests the ingest endpoint"""
         data: bytes = ujson.dumps(self.events).encode()


### PR DESCRIPTION
Recently, we had received a few 503 from axiom logging.
When the Client receives a 503 after few retries, it raise an Exception.
That's problematic because it also crashes the whole app.

How to reproduce in a production python app:
- update your logger with a 503 error: `axiom_py.Client(token=token, url_base="https://httpstat.us/503")`
- Have a FastAPI endpoint creating a log
- See the logging crashing the route

Another solution would be to move the try/except in the flush function of `logging.py`.

I'm not super fluent in python, feel free to propose changes.

Some related stack trace:

```
Exception in thread Thread-8:
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.12/threading.py", line 1433, in run
    self.function(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.12/site-packages/axiom_py/logging.py", line 67, in flush
    self.client.ingest_events(self.dataset, local_buffer)
  File "/usr/local/lib/python3.12/site-packages/axiom_py/client.py", line 262, in ingest_events
    return self.ingest(
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/axiom_py/client.py", line 239, in ingest
    res = self.session.post(
          ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 637, in post
    return self.request("POST", url, data=data, json=json, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests_toolbelt/sessions.py", line 76, in request
    return super(BaseUrlSession, self).request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 710, in send
    r = dispatch_hook("response", hooks, r, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/hooks.py", line 30, in dispatch_hook
    _hook_data = hook(hook_data, **kwargs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/axiom_py/client.py", line 182, in <lambda>
    "response": lambda r, *args, **kwargs: raise_response_error(r)
                                           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/axiom_py/client.py", line 145, in raise_response_error
    raise AxiomError(res.status_code, error_res)
axiom_py.client.AxiomError: API error 404: Not Found
```