### PR TITLE
fix: support edge parameter in clients

### DIFF
--- a/src/axiom_py/client.py
+++ b/src/axiom_py/client.py
@@ -171,6 +171,7 @@ class Client:  # pylint: disable=R0903
         org_id: Optional[str] = None,
         url: Optional[str] = None,
         edge_url: Optional[str] = None,
+        edge: Optional[str] = None,
     ):
         """
         Initialize the Axiom client.
@@ -187,6 +188,12 @@ class Client:  # pylint: disable=R0903
                 requests use `/v1/ingest/{dataset}` and query requests use
                 `/v1/query/_apl`.
                 Must be passed explicitly (not read from environment).
+                Takes precedence over `edge`.
+            edge: Edge domain for ingest/query operations (e.g.,
+                "eu-central-1.aws.edge.axiom.co"). When set, ingest
+                requests use `https://{edge}/v1/ingest/{dataset}` and query
+                requests use `https://{edge}/v1/query/_apl`.
+                Must be passed explicitly (not read from environment).
         """
         # fallback to env variables if not provided
         if token is None:
@@ -195,19 +202,21 @@ class Client:  # pylint: disable=R0903
             org_id = os.getenv("AXIOM_ORG_ID")
         if url is None:
             url = os.getenv("AXIOM_URL")
-        # Note: edge_url is NOT auto-read from environment.
+        # Note: edge_url and edge are NOT auto-read from environment.
         # Edge configuration must be explicit to avoid accidentally routing
-        # all requests through edge when AXIOM_EDGE_URL is set for
+        # all requests through edge when AXIOM_EDGE_URL or AXIOM_EDGE is set for
         # edge-specific tests. Create a separate Client with edge_url
         # for edge operations.
 
         # Normalize empty strings to None for edge config
         edge_url = edge_url or None
+        edge = edge or None
 
         # Store for building ingest/query endpoints
         self._token = token
         self._url = url
         self._edge_url = edge_url
+        self._edge = edge
 
         # Determine API base URL (for non-ingest/query operations)
         # This always uses AXIOM_URL (api.axiom.co) unless a custom url is set
@@ -250,45 +259,51 @@ class Client:  # pylint: disable=R0903
 
     def is_edge_configured(self) -> bool:
         """Check if edge is configured."""
-        return self._edge_url is not None
+        return self._edge_url is not None or self._edge is not None
 
     def _get_edge_ingest_url(self, dataset: str) -> Optional[str]:
         """
         Get the full edge ingest URL for a dataset.
         Returns None if edge is not configured.
         """
-        if self._edge_url is None:
-            return None
+        if self._edge_url is not None:
+            url = self._edge_url.rstrip("/")
+            parsed = urlparse(url)
+            path = parsed.path
 
-        url = self._edge_url.rstrip("/")
-        parsed = urlparse(url)
-        path = parsed.path
+            # If path is empty or just "/", append edge ingest format
+            if path == "" or path == "/":
+                return f"{parsed.scheme}://{parsed.netloc}/v1/ingest/{dataset}"
 
-        # If path is empty or just "/", append edge ingest format
-        if path == "" or path == "/":
-            return f"{parsed.scheme}://{parsed.netloc}/v1/ingest/{dataset}"
+            # edge_url has a custom path, use as-is
+            return url
 
-        # edge_url has a custom path, use as-is
-        return url
+        if self._edge is not None:
+            return f"https://{self._edge.rstrip('/')}/v1/ingest/{dataset}"
+
+        return None
 
     def _get_edge_query_url(self) -> Optional[str]:
         """
         Get the full edge query URL.
         Returns None if edge is not configured.
         """
-        if self._edge_url is None:
-            return None
+        if self._edge_url is not None:
+            url = self._edge_url.rstrip("/")
+            parsed = urlparse(url)
+            path = parsed.path
 
-        url = self._edge_url.rstrip("/")
-        parsed = urlparse(url)
-        path = parsed.path
+            # If path is empty or just "/", append edge query format
+            if path == "" or path == "/":
+                return f"{parsed.scheme}://{parsed.netloc}/v1/query/_apl"
 
-        # If path is empty or just "/", append edge query format
-        if path == "" or path == "/":
-            return f"{parsed.scheme}://{parsed.netloc}/v1/query/_apl"
+            # edge_url has a custom path, use as-is
+            return url
 
-        # edge_url has a custom path, use as-is
-        return url
+        if self._edge is not None:
+            return f"https://{self._edge.rstrip('/')}/v1/query/_apl"
+
+        return None
 
     def before_shutdown(self, func: Callable):
         self.before_shutdown_funcs.append(func)

--- a/src/axiom_py/client_async.py
+++ b/src/axiom_py/client_async.py
@@ -50,6 +50,7 @@ class AsyncClient:
         org_id: Optional[str] = None,
         url: Optional[str] = None,
         edge_url: Optional[str] = None,
+        edge: Optional[str] = None,
     ):
         """
         Initialize the async Axiom client.
@@ -64,6 +65,12 @@ class AsyncClient:
                 "https://eu-central-1.aws.edge.axiom.co"). When set, ingest
                 requests use `/v1/ingest/{dataset}` and query requests use
                 `/v1/query/_apl`.
+                Must be passed explicitly (not read from environment).
+                Takes precedence over `edge`.
+            edge: Edge domain for ingest/query operations (e.g.,
+                "eu-central-1.aws.edge.axiom.co"). When set, ingest
+                requests use `https://{edge}/v1/ingest/{dataset}` and query
+                requests use `https://{edge}/v1/query/_apl`.
                 Must be passed explicitly (not read from environment).
 
         Example:
@@ -80,18 +87,20 @@ class AsyncClient:
         if url is None:
             url = AXIOM_URL
 
-        # Note: edge_url is NOT auto-read from environment.
+        # Note: edge_url and edge are NOT auto-read from environment.
         # Edge configuration must be explicit to avoid accidentally routing
-        # all requests through edge when AXIOM_EDGE_URL is set for
+        # all requests through edge when AXIOM_EDGE_URL or AXIOM_EDGE is set for
         # edge-specific tests. Create a separate AsyncClient with edge_url
         # for edge operations.
 
         # Normalize empty strings to None for edge config
         edge_url = edge_url or None
+        edge = edge or None
 
         # Store for building ingest/query endpoints
         self._token = token
         self._edge_url = edge_url
+        self._edge = edge
 
         # Get common headers
         headers = get_common_headers(token, org_id)
@@ -129,45 +138,51 @@ class AsyncClient:
 
     def is_edge_configured(self) -> bool:
         """Check if edge is configured."""
-        return self._edge_url is not None
+        return self._edge_url is not None or self._edge is not None
 
     def _get_edge_ingest_url(self, dataset: str) -> Optional[str]:
         """
         Get the full edge ingest URL for a dataset.
         Returns None if edge is not configured.
         """
-        if self._edge_url is None:
-            return None
+        if self._edge_url is not None:
+            url = self._edge_url.rstrip("/")
+            parsed = urlparse(url)
+            path = parsed.path
 
-        url = self._edge_url.rstrip("/")
-        parsed = urlparse(url)
-        path = parsed.path
+            # If path is empty or just "/", append edge ingest format
+            if path == "" or path == "/":
+                return f"{parsed.scheme}://{parsed.netloc}/v1/ingest/{dataset}"
 
-        # If path is empty or just "/", append edge ingest format
-        if path == "" or path == "/":
-            return f"{parsed.scheme}://{parsed.netloc}/v1/ingest/{dataset}"
+            # edge_url has a custom path, use as-is
+            return url
 
-        # edge_url has a custom path, use as-is
-        return url
+        if self._edge is not None:
+            return f"https://{self._edge.rstrip('/')}/v1/ingest/{dataset}"
+
+        return None
 
     def _get_edge_query_url(self) -> Optional[str]:
         """
         Get the full edge query URL.
         Returns None if edge is not configured.
         """
-        if self._edge_url is None:
-            return None
+        if self._edge_url is not None:
+            url = self._edge_url.rstrip("/")
+            parsed = urlparse(url)
+            path = parsed.path
 
-        url = self._edge_url.rstrip("/")
-        parsed = urlparse(url)
-        path = parsed.path
+            # If path is empty or just "/", append edge query format
+            if path == "" or path == "/":
+                return f"{parsed.scheme}://{parsed.netloc}/v1/query/_apl"
 
-        # If path is empty or just "/", append edge query format
-        if path == "" or path == "/":
-            return f"{parsed.scheme}://{parsed.netloc}/v1/query/_apl"
+            # edge_url has a custom path, use as-is
+            return url
 
-        # edge_url has a custom path, use as-is
-        return url
+        if self._edge is not None:
+            return f"https://{self._edge.rstrip('/')}/v1/query/_apl"
+
+        return None
 
     async def ingest(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -325,8 +325,29 @@ class TestEdgeConfiguration(unittest.TestCase):
 
     def _clear_env(self):
         """Helper to clear edge-related env vars."""
+        os.environ.pop("AXIOM_EDGE", None)
         os.environ.pop("AXIOM_URL", None)
         os.environ.pop("AXIOM_EDGE_URL", None)
+
+    def test_edge_builds_correct_urls(self):
+        """Test that edge config builds correct edge ingest and query URLs."""
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+            client = Client(
+                token="xaat-test-token",
+                org_id="test-org",
+                edge="eu-central-1.aws.edge.axiom.co",
+            )
+            self.assertEqual(client._edge, "eu-central-1.aws.edge.axiom.co")
+            self.assertEqual(
+                client._get_edge_ingest_url("my-dataset"),
+                "https://eu-central-1.aws.edge.axiom.co/v1/ingest/my-dataset",
+            )
+            self.assertEqual(
+                client._get_edge_query_url(),
+                "https://eu-central-1.aws.edge.axiom.co/v1/query/_apl",
+            )
+            self.assertTrue(client.is_edge_configured())
 
     def test_edge_url_builds_correct_ingest_url(self):
         """Test that edge_url config builds correct edge ingest URL."""
@@ -357,6 +378,25 @@ class TestEdgeConfiguration(unittest.TestCase):
             self.assertEqual(
                 url,
                 "https://eu-central-1.aws.edge.axiom.co/v1/query/_apl",
+            )
+
+    def test_edge_url_takes_precedence_over_edge(self):
+        """Test that edge_url takes precedence over edge."""
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+            client = Client(
+                token="xaat-test-token",
+                org_id="test-org",
+                edge="ignored.aws.edge.axiom.co",
+                edge_url="https://custom-edge.example.com",
+            )
+            self.assertEqual(
+                client._get_edge_ingest_url("my-dataset"),
+                "https://custom-edge.example.com/v1/ingest/my-dataset",
+            )
+            self.assertEqual(
+                client._get_edge_query_url(),
+                "https://custom-edge.example.com/v1/query/_apl",
             )
 
     def test_no_edge_returns_none(self):
@@ -471,13 +511,16 @@ class TestEdgeConfiguration(unittest.TestCase):
             self._clear_env()
             # Set env var that should be ignored
             os.environ["AXIOM_EDGE_URL"] = "https://edge.example.com"
+            os.environ["AXIOM_EDGE"] = "eu-central-1.aws.edge.axiom.co"
 
             # Client should NOT pick up edge config from env
             client = Client(token="xaat-test-token", org_id="test-org")
             self.assertIsNone(client._edge_url)
+            self.assertIsNone(client._edge)
             self.assertFalse(client.is_edge_configured())
 
             os.environ.pop("AXIOM_EDGE_URL", None)
+            os.environ.pop("AXIOM_EDGE", None)
 
     def test_personal_token_rejected_for_edge_ingest(self):
         """Test that personal tokens are rejected for edge ingest."""
@@ -519,4 +562,16 @@ class TestEdgeConfiguration(unittest.TestCase):
                 edge_url="",
             )
             self.assertIsNone(client._edge_url)
+            self.assertFalse(client.is_edge_configured())
+
+    def test_empty_string_edge_treated_as_none(self):
+        """Test that empty string for edge is treated as None."""
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+            client = Client(
+                token="xaat-api-token",
+                org_id="test-org",
+                edge="",
+            )
+            self.assertIsNone(client._edge)
             self.assertFalse(client.is_edge_configured())

--- a/tests/test_edge_integration.py
+++ b/tests/test_edge_integration.py
@@ -607,16 +607,44 @@ class TestAsyncEdgeIntegration(unittest.TestCase):
         asyncio.run(run_test())
 
 
-class TestAsyncEdgeURLConfiguration(unittest.TestCase):
-    """Test async edge_url configuration."""
+class TestAsyncEdgeConfiguration(unittest.TestCase):
+    """Test async edge configuration."""
+
+    def _clear_env(self):
+        os.environ.pop("AXIOM_EDGE", None)
+        os.environ.pop("AXIOM_URL", None)
+        os.environ.pop("AXIOM_EDGE_URL", None)
+
+    def test_async_edge_builds_correct_urls(self):
+        """Test async edge builds correct ingest and query URLs."""
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+
+            client = AsyncClient(
+                token="xaat-test-token",
+                org_id="test-org",
+                edge="eu-central-1.aws.edge.axiom.co",
+            )
+
+            self.assertEqual(client._edge, "eu-central-1.aws.edge.axiom.co")
+            self.assertEqual(
+                client._get_edge_ingest_url("my-dataset"),
+                "https://eu-central-1.aws.edge.axiom.co/v1/ingest/my-dataset",
+            )
+            self.assertEqual(
+                client._get_edge_query_url(),
+                "https://eu-central-1.aws.edge.axiom.co/v1/query/_apl",
+            )
+            self.assertTrue(client.is_edge_configured())
 
     def test_async_edge_url_builds_correct_urls(self):
         """Test async edge_url builds correct ingest and query URLs."""
         from unittest.mock import patch
 
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("AXIOM_URL", None)
-            os.environ.pop("AXIOM_EDGE_URL", None)
+            self._clear_env()
 
             client = AsyncClient(
                 token="xaat-test-token",
@@ -638,8 +666,7 @@ class TestAsyncEdgeURLConfiguration(unittest.TestCase):
         from unittest.mock import patch
 
         with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("AXIOM_URL", None)
-            os.environ.pop("AXIOM_EDGE_URL", None)
+            self._clear_env()
 
             client = AsyncClient(
                 token="xaat-test-token",
@@ -657,3 +684,57 @@ class TestAsyncEdgeURLConfiguration(unittest.TestCase):
                 query_url,
                 "https://eu-central-1.aws.edge.axiom.co/v1/query/_apl",
             )
+
+    def test_async_edge_url_takes_precedence_over_edge(self):
+        """Test that async edge_url takes precedence over edge."""
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+
+            client = AsyncClient(
+                token="xaat-test-token",
+                org_id="test-org",
+                edge="ignored.aws.edge.axiom.co",
+                edge_url="https://custom-edge.example.com",
+            )
+
+            self.assertEqual(
+                client._get_edge_ingest_url("my-dataset"),
+                "https://custom-edge.example.com/v1/ingest/my-dataset",
+            )
+            self.assertEqual(
+                client._get_edge_query_url(),
+                "https://custom-edge.example.com/v1/query/_apl",
+            )
+
+    def test_async_edge_not_read_from_env(self):
+        """Test that async edge config is NOT auto-read from environment."""
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+            os.environ["AXIOM_EDGE"] = "eu-central-1.aws.edge.axiom.co"
+            os.environ["AXIOM_EDGE_URL"] = "https://custom-edge.example.com"
+
+            client = AsyncClient(token="xaat-test-token", org_id="test-org")
+
+            self.assertIsNone(client._edge)
+            self.assertIsNone(client._edge_url)
+            self.assertFalse(client.is_edge_configured())
+
+    def test_async_empty_string_edge_treated_as_none(self):
+        """Test that async edge empty string is treated as None."""
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, {}, clear=False):
+            self._clear_env()
+
+            client = AsyncClient(
+                token="xaat-test-token",
+                org_id="test-org",
+                edge="",
+            )
+
+            self.assertIsNone(client._edge)
+            self.assertFalse(client.is_edge_configured())


### PR DESCRIPTION
## Summary
- add an `edge` constructor option to `Client` and `AsyncClient` so axiom-py matches the documented API and the Go client’s `SetEdge` / `SetEdgeURL` split
- keep `edge_url` as the higher-precedence option when both are provided
- add regression coverage for sync and async edge URL building, precedence, empty-string normalization, and the existing explicit-only environment behavior

## Notes
- `edge` was added after `edge_url` in the Python constructor signature so existing positional `edge_url` callers keep working unchanged

## Testing
- `uv run ruff check src/axiom_py/client.py src/axiom_py/client_async.py tests/test_client.py tests/test_edge_integration.py`
- `uv run ruff format --check src/axiom_py/client.py src/axiom_py/client_async.py tests/test_client.py tests/test_edge_integration.py`
- `uv run pytest tests/test_client.py::TestEdgeConfiguration tests/test_edge_integration.py::TestAsyncEdgeConfiguration`

Linear: https://linear.app/axiom/issue/AXM-11747/support-edge-parameter-in-axiom-py
