### PR TITLE
fix: enable retry on POST requests for connection errors

### DIFF
--- a/src/axiom_py/client.py
+++ b/src/axiom_py/client.py
@@ -218,8 +218,16 @@ class Client:  # pylint: disable=R0903
             api_base = f"{parsed.scheme}://{parsed.netloc}"
 
         # set exponential retries
+        # allowed_methods includes POST so that connection errors
+        # (e.g. RemoteDisconnected from stale keep-alive connections)
+        # are retried on ingest calls, not just GET requests.
         retries = Retry(
-            total=3, backoff_factor=2, status_forcelist=[500, 502, 503, 504]
+            total=3,
+            backoff_factor=2,
+            status_forcelist=[500, 502, 503, 504],
+            allowed_methods=frozenset(
+                ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE"]
+            ),
         )
 
         # Create session for all API operations


### PR DESCRIPTION
urllib3's Retry excludes POST from allowed_methods by default, which means connection errors like RemoteDisconnected on ingest calls are never retried. This causes failures when stale keep-alive connections are reused from the pool after the server-side idle timeout (10s) closes them.

Adding POST to allowed_methods lets the existing retry logic (3 attempts, exponential backoff) handle these transient connection failures transparently.

- 